### PR TITLE
add support for non logback slf4j backends like log4j

### DIFF
--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/util/LogManager.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/util/LogManager.java
@@ -6,6 +6,9 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
+
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.slf4j.LoggerFactory;
 
 /**
@@ -15,7 +18,88 @@ import org.slf4j.LoggerFactory;
  */
 public class LogManager {
 
+	private static final LogManager DEFAULT_LOG_MANAGER = createDefaultLogManager();
+	
+    private static LogManager createDefaultLogManager() {
+    	LogManager defaultLogManager = new LogManager();
+    	return defaultLogManager ;
+    }
+    
+	/** 
+	 * Use the {@link #setInstance(LogManager)} method to
+	 * customize the active LogManager implementation.
+	 */
+    private final static AtomicReference<LogManager> refLogManagerImpl = new AtomicReference<>(DEFAULT_LOG_MANAGER);
+	
+    /**
+     * <p>
+     * Replace the "default" LogManager implementation
+     * with a custom implementation.
+     * 
+     * <p>
+     * Useful if the app container running sdk-dslink-java
+     * is using an Simple Logging Facade for Java (SLF4J)
+     * backend other than logback.
+     * 
+     * @param customLogManager In-parameter, a LogManager instance. 
+     */
+	public static void setInstance( LogManager customLogManager ) {
+		
+		if (null==customLogManager) {
+			throw new IllegalArgumentException("attempt to set null customLogManager");
+		}
+		
+		refLogManagerImpl.set(customLogManager);
+    }	
+	
     public static void setLevel(String level) {
+    	LogManager custom = refLogManagerImpl.get();
+    	custom.doSetLevel(level);
+    }
+
+	/**
+     * Configures the root logger with a different layout.
+     */
+    public static void configure() {
+    	LogManager custom = refLogManagerImpl.get();    	
+		custom.doConfigure();
+    }
+
+    /**
+     * Sets the global logging level
+     *
+     * @param level Level to set
+     */
+    public static void setLevel(Level level) {
+    	LogManager custom = refLogManagerImpl.get();    	
+    	custom.doSetLevel(level);
+    }
+
+	/**
+     * Retrieves the root logging level, which may also be the global
+     * root level.
+     *
+     * @return Root logger level
+     */
+    public static Level getLevel() {
+    	LogManager custom = refLogManagerImpl.get();
+    	return custom.doGetLevel();
+    }
+
+    private static Logger getLogger() {
+    	LogManager custom = refLogManagerImpl.get();
+    	return custom.doGetLogger();
+    }
+
+    /**
+     * Protected to allow sub-classes to call the constructor but don't
+     * permit outsiders to construct LogManager instances.
+     */
+    protected LogManager() {}
+    
+    // Method implementations for the "Default" LogManager
+    
+	protected void doSetLevel(String level) {
         if (level == null)
             throw new NullPointerException("level");
         level = level.toLowerCase();
@@ -41,12 +125,10 @@ public class LogManager {
             default:
                 throw new RuntimeException("Unknown log level: " + level);
         }
-    }
 
-    /**
-     * Configures the root logger with a different layout.
-     */
-    public static void configure() {
+    }
+    
+    protected void doConfigure() {
         Logger logger = getLogger();
         LoggerContext loggerContext = logger.getLoggerContext();
         loggerContext.reset();
@@ -64,28 +146,17 @@ public class LogManager {
         logger.addAppender(appender);
     }
 
-    /**
-     * Sets the global logging level
-     *
-     * @param level Level to set
-     */
-    public static void setLevel(Level level) {
+	protected void doSetLevel(Level level) {
         if (level == null)
             throw new NullPointerException("level");
         getLogger().setLevel(level);
     }
-
-    /**
-     * Retrieves the root logging level, which may also be the global
-     * root level.
-     *
-     * @return Root logger level
-     */
-    public static Level getLevel() {
-        return getLogger().getLevel();
+    
+    protected Level doGetLevel() {  
+    	return getLogger().getLevel(); 
     }
-
-    private static Logger getLogger() {
-        return (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-    }
+	
+    protected Logger doGetLogger() { 
+    	return (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME); 
+    }	
 }


### PR DESCRIPTION
Add support for customizing the LogManager implementation via the new
LogManager#setInstance method. This permits sdk-dslink-java users to
use slf4j backends other than logback like log4j. sdk-dslink-java users
would simply extend LogManager and overwrite the do* methods to create a
LogManager compatible with their chosen slf4j backend.

Regrettably customizers will still need to add logback-classic as a
dependency because LogManager's interface contains logback classes like
ch.qos.logback.classic.Level and ch.qos.logback.classic.Logger in its
interface.

This pull request was discussed here:
https://iot-dsa.slack.com/archives/general/p1432304986000057
https://iot-dsa.slack.com/archives/general/p1432740497000012
https://iot-dsa.slack.com/archives/general/p1432751857000028
https://iot-dsa.slack.com/archives/general/p1432752832000032
etc.