### PR TITLE
Fix missing rows from GetHistory requests.

### DIFF
--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/actions/table/Table.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/actions/table/Table.java
@@ -242,7 +242,7 @@ public class Table {
             JsonObject obj = new JsonObject();
             obj.put("rid", rid);
             obj.put("stream", StreamState.CLOSED.getJsonName());
-            writer.writeResponse(obj,false);
+            writer.writeResponse(obj, false);
             this.writer = null;
             Handler<Void> closeHandler = this.closeHandler;
             if (closeHandler != null) {
@@ -336,7 +336,7 @@ public class Table {
         JsonObject obj = new JsonObject();
         obj.put("rid", rid);
         obj.put("stream", StreamState.OPEN.getJsonName());
-        writer.writeResponse(obj,false);
+        writer.writeResponse(obj, false);
     }
 
     private void write(DataHandler writer,
@@ -361,7 +361,7 @@ public class Table {
         if (updates != null) {
             obj.put("updates", updates);
         }
-        writer.writeResponse(obj,false);
+        writer.writeResponse(obj, false);
     }
 
     private JsonArray processRow(Row row) {

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/actions/table/Table.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/actions/table/Table.java
@@ -242,7 +242,7 @@ public class Table {
             JsonObject obj = new JsonObject();
             obj.put("rid", rid);
             obj.put("stream", StreamState.CLOSED.getJsonName());
-            writer.writeResponse(obj);
+            writer.writeResponse(obj,false);
             this.writer = null;
             Handler<Void> closeHandler = this.closeHandler;
             if (closeHandler != null) {
@@ -336,7 +336,7 @@ public class Table {
         JsonObject obj = new JsonObject();
         obj.put("rid", rid);
         obj.put("stream", StreamState.OPEN.getJsonName());
-        writer.writeResponse(obj);
+        writer.writeResponse(obj,false);
     }
 
     private void write(DataHandler writer,

--- a/sdk/historian/src/main/java/org/dsa/iot/historian/stats/GetHistory.java
+++ b/sdk/historian/src/main/java/org/dsa/iot/historian/stats/GetHistory.java
@@ -194,6 +194,7 @@ public class GetHistory implements Handler<ActionResult> {
             }
         }
         if (batch != null) {
+            table.waitForStream(5000,true);
             table.addBatchRows(batch);
         }
     }

--- a/sdk/historian/src/main/java/org/dsa/iot/historian/stats/GetHistory.java
+++ b/sdk/historian/src/main/java/org/dsa/iot/historian/stats/GetHistory.java
@@ -194,7 +194,7 @@ public class GetHistory implements Handler<ActionResult> {
             }
         }
         if (batch != null) {
-            table.waitForStream(5000,true);
+            table.waitForStream(5000, true);
             table.addBatchRows(batch);
         }
     }


### PR DESCRIPTION
Julien (@example6), this fix was verified by @kaendfinger and Paul - maybe they can show you the before and after.

Changes:

- This change prevents the merging (coalescing) of any table rows.  I can't imagine a case where anyone would ever want to skip rows in a table.  @rinick can you think of case?

- GetHistory now waits for the stream to establish before sending rows.

