### PR TITLE
Multi-child updates and Requester-side action result editors

### DIFF
--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
@@ -14,6 +14,7 @@ import org.dsa.iot.dslink.util.json.JsonArray;
 import org.dsa.iot.dslink.util.json.JsonObject;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -510,5 +511,19 @@ public class ListResponse extends Response {
                 throw new UnsupportedOperationException();
             }
         });
+    }
+
+    public void multiChildrenUpdate(List<Node> children) {
+        JsonArray updates = new JsonArray();
+
+        for (Node child : children) {
+            updates.add(getChildUpdate(child, false));
+        }
+
+        JsonObject resp = new JsonObject();
+        resp.put("rid", getRid());
+        resp.put("stream", StreamState.OPEN.getJsonName());
+        resp.put("updates", updates);
+        link.getWriter().writeResponse(resp);
     }
 }

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
@@ -477,17 +477,33 @@ public class ListResponse extends Response {
             String type = data.get("type");
             ValueType valType = ValueType.toValueType(type);
             Parameter param = new Parameter(name, valType);
+
+            String editor = data.get("editor");
+
+            if (editor != null) {
+                JsonObject editorMeta = data.get("editorMeta");
+                param.setEditorType(EditorType.make(editor, editorMeta));
+            }
+
+            Object def = data.get("default");
+            if (def != null) {
+                param.setDefaultValue(ValueUtils.toValue(def));
+            }
+
+            String description = data.get("description");
+            String placeholder = data.get("placeholder");
+
+            if (description != null) {
+                param.setDescription(description);
+            }
+
+            if (placeholder != null) {
+                param.setPlaceHolder(placeholder);
+            }
+
             if (isCol) {
                 act.addResult(param);
             } else {
-                String editor = data.get("editor");
-                if (editor != null) {
-                    param.setEditorType(EditorType.make(editor));
-                }
-                Object def = data.get("default");
-                if (def != null) {
-                    param.setDefaultValue(ValueUtils.toValue(def));
-                }
                 act.addParameter(param);
             }
         }

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/Node.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/Node.java
@@ -426,9 +426,8 @@ public class Node {
     public Node addChild(Node node) {
         synchronized (childrenLock) {
             String name = node.getName();
-            if (children == null) {
-                children = new ConcurrentHashMap<>();
-            } else if (children.containsKey(name)) {
+            maybeInitializeChildren();
+            if (children.containsKey(name)) {
                 return children.get(name);
             }
 
@@ -465,15 +464,12 @@ public class Node {
         synchronized (childrenLock) {
             for (Node node : nodes) {
                 String name = node.getName();
-                if (children == null) {
-                    children = new ConcurrentHashMap<>();
-                } else if (children.containsKey(name)) {
+                maybeInitializeChildren();
+                if (children.containsKey(name)) {
                     continue;
                 }
 
-                if (node.getProfile() == null) {
-                    node.setProfile(profile);
-                }
+                node.maybeInitializeProfile(profile);
                 children.put(name, node);
 
                 if (node.isSerializable()) {
@@ -488,6 +484,18 @@ public class Node {
 
         if (reserialize) {
             markChanged();
+        }
+    }
+
+    private void maybeInitializeProfile(String profile) {
+        if (getProfile() == null) {
+            setProfile(profile);
+        }
+    }
+
+    private void maybeInitializeChildren() {
+        if (children == null) {
+            children = new ConcurrentHashMap<>();
         }
     }
 

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/SubscriptionManager.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/SubscriptionManager.java
@@ -10,10 +10,7 @@ import org.dsa.iot.dslink.util.StringUtils;
 import org.dsa.iot.dslink.util.json.JsonArray;
 import org.dsa.iot.dslink.util.json.JsonObject;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -245,6 +242,22 @@ public class SubscriptionManager {
         ListResponse resp = pathSubsMap.get(parent.getPath());
         if (resp != null) {
             resp.childUpdate(child, removed);
+        }
+    }
+
+    /**
+     * Posts multiple children updates to notify all remote endpoints of updates.
+     *
+     * @param parent Common parent.
+     * @param children Children.
+     */
+    public void postMultiChildUpdate(Node parent, List<Node> children) {
+        if (parent == null) {
+            return;
+        }
+        ListResponse resp = pathSubsMap.get(parent.getPath());
+        if (resp != null) {
+            resp.multiChildrenUpdate(children);
         }
     }
 


### PR DESCRIPTION
Adds support for multi-added-child updates (prevents issue with data sort of streaming in when adding lots of nodes). Also fixes an issue in the requester where editors were not being decoded correctly when present on the action result.