### PR TITLE
Fix multiple population bugs in the requester.

### DIFF
--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
@@ -125,9 +125,15 @@ public class ListResponse extends Response {
             }
         } else if (name.startsWith("$")) {
             name = name.substring(1);
-            if ("is".equals(name) && node.getProfile() != v) {
-                node.reset();
-                node.setProfile((String) v);
+            if ("is".equals(name)) {
+                if (v == null) {
+                    v = "node"; // $is should always have a value. A null value is a bug in the responder that sent it.
+                }
+
+                if (!node.getProfile().equals(v)) {
+                    node.reset();
+                    node.setProfile((String) v);
+                }
             } else if ("interface".equals(name)) {
                 node.setInterfaces((String) v);
             } else if ("invokable".equals(name)) {
@@ -155,7 +161,9 @@ public class ListResponse extends Response {
                 node.setWritable(Writable.toEnum(string));
             } else if ("type".equals(name)) {
                 ValueType type = ValueType.toValueType((String) v);
-                node.setValueType(type);
+                if (!type.equals(node.getValueType())) {
+                    node.setValueType(type);
+                }
             } else if ("name".equals(name)) {
                 node.setDisplayName((String) v);
             } else if ("hidden".equals(name)) {

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/methods/responses/ListResponse.java
@@ -125,7 +125,7 @@ public class ListResponse extends Response {
             }
         } else if (name.startsWith("$")) {
             name = name.substring(1);
-            if ("is".equals(name)) {
+            if ("is".equals(name) && node.getProfile() != v) {
                 node.reset();
                 node.setProfile((String) v);
             } else if ("interface".equals(name)) {

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/Node.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/Node.java
@@ -630,11 +630,14 @@ public class Node {
      * @see Action
      */
     public Value setConfig(String name, Value value) {
+        if (value == null) {
+            removeConfig(name);
+            return null;
+        }
+
         synchronized (configLock) {
             name = checkAndEncodeName(name);
-            if (value == null) {
-                throw new NullPointerException("value");
-            } else if (configs == null) {
+            if (configs == null) {
                 configs = new ConcurrentHashMap<>();
             }
             switch (name) {
@@ -738,11 +741,14 @@ public class Node {
      * @return The previous value, if any.
      */
     public Value setRoConfig(String name, Value value) {
+        if (value == null) {
+            removeRoConfig(name);
+            return null;
+        }
+
         synchronized (roConfigLock) {
             name = checkAndEncodeName(name);
-            if (value == null) {
-                throw new NullPointerException("value");
-            } else if (roConfigs == null) {
+            if (roConfigs == null) {
                 roConfigs = new ConcurrentHashMap<>();
             }
 
@@ -789,6 +795,7 @@ public class Node {
      * @return Attribute value or null if it didn't exist
      */
     public Value removeAttribute(String name) {
+
         name = StringUtils.encodeName(name);
         Value ret;
         synchronized (attributeLock) {
@@ -824,11 +831,14 @@ public class Node {
      * @return The previous attribute value, if any
      */
     public Value setAttribute(String name, Value value) {
+        if (value == null) {
+            removeAttribute(name);
+            return null;
+        }
+
         synchronized (attributeLock) {
             name = checkAndEncodeName(name);
-            if (value == null) {
-                throw new NullPointerException("value");
-            } else if (attribs == null) {
+            if (attribs == null) {
                 attribs = new ConcurrentHashMap<>();
             }
             value.setImmutable();

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/Node.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/Node.java
@@ -630,14 +630,11 @@ public class Node {
      * @see Action
      */
     public Value setConfig(String name, Value value) {
-        if (value == null) {
-            removeConfig(name);
-            return null;
-        }
-
         synchronized (configLock) {
             name = checkAndEncodeName(name);
-            if (configs == null) {
+            if (value == null) {
+                throw new NullPointerException("value");
+            } else if (configs == null) {
                 configs = new ConcurrentHashMap<>();
             }
             switch (name) {
@@ -741,14 +738,11 @@ public class Node {
      * @return The previous value, if any.
      */
     public Value setRoConfig(String name, Value value) {
-        if (value == null) {
-            removeRoConfig(name);
-            return null;
-        }
-
         synchronized (roConfigLock) {
             name = checkAndEncodeName(name);
-            if (roConfigs == null) {
+            if (value == null) {
+                throw new NullPointerException("value");
+            } else if (roConfigs == null) {
                 roConfigs = new ConcurrentHashMap<>();
             }
 
@@ -795,7 +789,6 @@ public class Node {
      * @return Attribute value or null if it didn't exist
      */
     public Value removeAttribute(String name) {
-
         name = StringUtils.encodeName(name);
         Value ret;
         synchronized (attributeLock) {
@@ -831,14 +824,11 @@ public class Node {
      * @return The previous attribute value, if any
      */
     public Value setAttribute(String name, Value value) {
-        if (value == null) {
-            removeAttribute(name);
-            return null;
-        }
-
         synchronized (attributeLock) {
             name = checkAndEncodeName(name);
-            if (attribs == null) {
+            if (value == null) {
+                throw new NullPointerException("value");
+            } else if (attribs == null) {
                 attribs = new ConcurrentHashMap<>();
             }
             value.setImmutable();

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueType.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueType.java
@@ -111,6 +111,10 @@ public final class ValueType {
      * @return Converted type
      */
     public static ValueType toValueType(String type) {
+        if (type == null) {
+            return ValueType.DYNAMIC;
+        }
+
         switch (type) {
             case JSON_NUMBER:
             case JSON_INT:

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueType.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueType.java
@@ -155,4 +155,9 @@ public final class ValueType {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        return 37 * toJsonString().hashCode();
+    }
 }

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueType.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueType.java
@@ -147,4 +147,12 @@ public final class ValueType {
                 return DYNAMIC;
         }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof ValueType) {
+            return ((ValueType) other).toJsonString().equals(toJsonString());
+        }
+        return false;
+    }
 }

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueUtils.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/ValueUtils.java
@@ -36,7 +36,7 @@ public class ValueUtils {
         } else if (type.compare(ValueType.BINARY)) {
             return new Value((byte[]) null, time);
         }
-        throw new RuntimeException(ERROR_MSG + type.getRawName());
+        return new Value((String) null);
     }
 
     /**


### PR DESCRIPTION
- Allow setAttribute(), setConfig(), and setRoConfig() to be called with a null value which will remove the given attribute.
- Fix a bug that prevented empty values to be created for when a requester sends a null value for any metadata attributes.
- Parse invalid value types as dynamic.