### PR TITLE
Added initialization of watch node type based on the watched path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ env:
   - secure: HedklAPTdQAEhwsLhCwGco62/1Hq00nYgB+0MZYaVEb9KVdKxgZUswNidtzXVLha9TTOe3ewTmVjsd+Hs0wyyq6TZh8TUKlVPrJc1wd4wkurCK8JZjqUxBV2EydYmGM7j/CHpci1rcGv3QNQRwf2ZwfAoW5YPObJqqZvwk3GYgg=
   - secure: g+rMdXQTBwVb5S58Mj2uKbhwLE1N+Rc/3qGIEzfLY8V5Jj2beak8uNH+m/7dmRPBYLaL6QP5ndt6cY47w3lcXWGa00xeve12BHk9i5dvzx4hDZ18PoWGA5iB/U1Aj4I8USrASliyb2dqHtQg0V2nixgHuNdlJiwDgRNROHAdsQg=
 install: /bin/true
-script: ./ci/script/build.sh
-after_script:
-- ./ci/script/deploy.sh
+script:
+  - export BRANCH_NAME=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - ./ci/script/build.sh
+  - ./ci/script/run_integrated_tests.sh
+after_success:
+  - ./ci/script/deploy.sh
 cache:
   directories:
     - $HOME/.gradle

--- a/ci/script/build.sh
+++ b/ci/script/build.sh
@@ -2,4 +2,3 @@
 
 # Perform a raw build
 ./gradlew build distZip
-

--- a/ci/script/run_integrated_tests.sh
+++ b/ci/script/run_integrated_tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+wget https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip
+unzip dartsdk-linux-x64-release.zip
+CURRENT_DIR="$(pwd)"
+
+git clone https://github.com/IOT-DSA/dslink-dart-test
+
+cd dslink-dart-test/
+${CURRENT_DIR}/dart-sdk/bin/pub get
+
+${CURRENT_DIR}/dart-sdk/bin/dart tool/grind.dart run-tests-for-sdk-pull-request

--- a/examples/requester/src/main/java/org/dsa/iot/requester/Main.java
+++ b/examples/requester/src/main/java/org/dsa/iot/requester/Main.java
@@ -21,7 +21,6 @@ import java.util.Set;
  * @author Samuel Grenier
  */
 public class Main extends DSLinkHandler {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
     private DSLink link;

--- a/sdk/historian/src/main/java/org/dsa/iot/historian/database/Watch.java
+++ b/sdk/historian/src/main/java/org/dsa/iot/historian/database/Watch.java
@@ -4,7 +4,9 @@ import org.dsa.iot.dslink.DSLink;
 import org.dsa.iot.dslink.DSLinkHandler;
 import org.dsa.iot.dslink.DSLinkProvider;
 import org.dsa.iot.dslink.link.Requester;
+import org.dsa.iot.dslink.methods.requests.ListRequest;
 import org.dsa.iot.dslink.methods.requests.SetRequest;
+import org.dsa.iot.dslink.methods.responses.ListResponse;
 import org.dsa.iot.dslink.node.Node;
 import org.dsa.iot.dslink.node.NodeBuilder;
 import org.dsa.iot.dslink.node.Permission;
@@ -137,6 +139,8 @@ public class Watch {
         watchedPath = node.getName().replaceAll("%2F", "/").replaceAll("%2E", ".");
         initData(node);
 
+        initializeWatchDataType();
+
         createUnsubscribeAction(perm);
 
         new OverwriteHistoryAction(this, node, perm, db);
@@ -144,6 +148,16 @@ public class Watch {
 
         addGetHistoryActionAlias();
         group.addWatch(this);
+    }
+
+    private void initializeWatchDataType() {
+        getRequester().list(new ListRequest(watchedPath), new Handler<ListResponse>() {
+            @Override
+            public void handle(ListResponse event) {
+                ValueType valueType = event.getNode().getValueType();
+                node.setValueType(valueType);
+            }
+        });
     }
 
     private void createUnsubscribeAction(Permission perm) {


### PR DESCRIPTION
This is to make Project Assist (PA) able to plot data from etsdb. The problem is that when you give it a history node, the graphs take into account the datatype of the Watch Node.

So to get this to work, we needed to make the watch node type the same as the watched node type.