### PR TITLE
Add MsgPack dependency back to runtime manager.

### DIFF
--- a/runtimes/container/build.gradle
+++ b/runtimes/container/build.gradle
@@ -17,6 +17,7 @@ compileJava {
 dependencies {
     provided 'com.google.code.findbugs:annotations:3.0.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.1'
+    compile 'org.msgpack:jackson-dataformat-msgpack:0.8.14'
     compile project(':internal/runtime_shared')
 }
 


### PR DESCRIPTION
The runtime manager should still retain a dependency to MsgPack. This allows links that are built against an old SDK to work correctly.

@d-shapiro 
