### PR TITLE
Fix NullPointerException in Value.toString()

### DIFF
--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/Value.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/Value.java
@@ -387,15 +387,15 @@ public class Value {
     public String toString() {
         switch (type.toJsonString()) {
             case ValueType.JSON_NUMBER:
-                return number.toString();
+                return String.valueOf(number);
             case ValueType.JSON_BOOL:
-                return bool.toString();
+                return String.valueOf(bool);
             case ValueType.JSON_STRING:
-                return string;
+                return String.valueOf(string);
             case ValueType.JSON_MAP:
-                return map.toString();
+                return map == null? "null" : map.toString();
             case ValueType.JSON_ARRAY:
-                return array.toString();
+                return array == null? "null" : array.toString();
             case ValueType.JSON_BINARY:
                 return Arrays.toString(binary);
             default:

--- a/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/Value.java
+++ b/sdk/dslink/src/main/java/org/dsa/iot/dslink/node/value/Value.java
@@ -393,9 +393,9 @@ public class Value {
             case ValueType.JSON_STRING:
                 return String.valueOf(string);
             case ValueType.JSON_MAP:
-                return map == null? "null" : map.toString();
+                return String.valueOf(map);
             case ValueType.JSON_ARRAY:
-                return array == null? "null" : array.toString();
+                return String.valueOf(array);
             case ValueType.JSON_BINARY:
                 return Arrays.toString(binary);
             default:

--- a/sdk/dslink/src/test/java/org/dsa/iot/dslink/node/value/ValueTest.java
+++ b/sdk/dslink/src/test/java/org/dsa/iot/dslink/node/value/ValueTest.java
@@ -1,6 +1,7 @@
 package org.dsa.iot.dslink.node.value;
 
 import org.dsa.iot.dslink.util.json.JsonArray;
+import org.dsa.iot.dslink.util.json.JsonObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -96,4 +97,20 @@ public class ValueTest {
         Assert.assertFalse(d.equals(e));
     }
 
+    @Test
+    public void testNullValues() {
+        Value a = new Value((Number) null);
+        Value b = new Value((Boolean) null);
+        Value c = new Value((String) null);
+        Value d = new Value((byte[]) null);
+        Value e = new Value((JsonObject) null);
+        Value f = new Value((JsonArray) null);
+        
+        Assert.assertEquals("null", a.toString());
+        Assert.assertEquals("null", b.toString());
+        Assert.assertEquals("null", c.toString());
+        Assert.assertEquals("null", d.toString());
+        Assert.assertEquals("null", e.toString());
+        Assert.assertEquals("null", f.toString());
+    }
 }


### PR DESCRIPTION
Nothing prevents passing null into the Value constructors (either via documented contract or eager NullPointerException), so I presume that null is a valid argument; however, calling toString() results in a NullPointerException in this scenario when it need not. Changed toString() to handle null gracefully by returning "null" rather than throw a NullPointerException. Also added a unit test to test this scenario.